### PR TITLE
Remove commons-io in favor of JDK 11+ features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,12 +51,12 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
 
-    - name: 'Setup: Install JDK 17'
+    - name: 'Setup: Install JDK 21'
       uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       with:
         distribution: 'temurin'
         java-version: |
-          17
+          21
 
     - name: 'Build'
       run: ${{ matrix.mvn }} clean install

--- a/codeowners-reader/pom.xml
+++ b/codeowners-reader/pom.xml
@@ -40,11 +40,6 @@
     </dependency>
 
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -81,7 +76,7 @@
         <configuration>
           <toolchains>
             <jdk>
-              <version>17</version>
+              <version>21</version>
             </jdk>
           </toolchains>
         </configuration>

--- a/codeowners-reader/src/main/java/nl/basjes/codeowners/CodeOwners.java
+++ b/codeowners-reader/src/main/java/nl/basjes/codeowners/CodeOwners.java
@@ -27,12 +27,12 @@ import org.antlr.v4.runtime.CodePointCharStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
-import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -63,7 +63,7 @@ public class CodeOwners extends CodeOwnersBaseVisitor<Void> {
      * @throws IOException In case of problems.
      */
     public CodeOwners(File file) throws IOException {
-        this(FileUtils.readFileToString(file, UTF_8));
+        this(Files.readString(file.toPath()));
     }
 
     private static final String IMPLICIT_SECTION_NAME = "Implicit Default Section";

--- a/enforcer/pom.xml
+++ b/enforcer/pom.xml
@@ -100,7 +100,7 @@
         <configuration>
           <toolchains>
             <jdk>
-              <version>17</version>
+              <version>21</version>
             </jdk>
           </toolchains>
         </configuration>

--- a/gitignore-reader/pom.xml
+++ b/gitignore-reader/pom.xml
@@ -34,11 +34,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -75,7 +70,7 @@
         <configuration>
           <toolchains>
             <jdk>
-              <version>17</version>
+              <version>21</version>
             </jdk>
           </toolchains>
         </configuration>

--- a/gitignore-reader/src/main/java/nl/basjes/gitignore/GitIgnore.java
+++ b/gitignore-reader/src/main/java/nl/basjes/gitignore/GitIgnore.java
@@ -17,7 +17,6 @@
 
 package nl.basjes.gitignore;
 
-import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,14 +24,13 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import static java.lang.Boolean.TRUE;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.commons.io.FilenameUtils.separatorsToUnix;
 
 /**
  * A class that holds a single .gitignore file
@@ -55,7 +53,7 @@ public class GitIgnore {
     }
 
     public GitIgnore(String projectRelativeBaseDir, File file) throws IOException {
-        this(projectRelativeBaseDir, FileUtils.readFileToString(file, UTF_8));
+        this(projectRelativeBaseDir, Files.readString(file.toPath()));
     }
 
     public GitIgnore(String gitIgnoreContent) {
@@ -172,7 +170,7 @@ public class GitIgnore {
      * @return A standardized form.
      */
     static String standardizeFilename(String filename) {
-        String unixifiedName = separatorsToUnix(filename);
+        String unixifiedName = filename.replace("\\", "/");
         if (!unixifiedName.matches("^[a-zA-Z]:/.*")) {
             unixifiedName = GITIGNORE_PATH_SEPARATOR + unixifiedName;
         }

--- a/gitignore-reader/src/test/java/nl/basjes/gitignore/TestGitIgnoreFiles.java
+++ b/gitignore-reader/src/test/java/nl/basjes/gitignore/TestGitIgnoreFiles.java
@@ -33,7 +33,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static nl.basjes.gitignore.GitIgnore.standardizeFilename;
-import static org.apache.commons.io.FilenameUtils.separatorsToWindows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -184,6 +183,10 @@ class TestGitIgnoreFiles {
                 .collect(Collectors.toList());
             checkIgnoredList(ignored);
         }
+    }
+
+    String separatorsToWindows(String path) {
+        return path.replace("/", "\\");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,9 @@
     <maven.minimal.version>3.9.2</maven.minimal.version>
     <enforcer-api.version>3.5.0</enforcer-api.version>
 
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
-    <maven.compiler.release>8</maven.compiler.release>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
 
     <maven-artifact-plugin.version>3.5.1</maven-artifact-plugin.version>
     <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
@@ -67,7 +67,6 @@
     <antlr.version>4.13.1</antlr.version>
     <junit5.version>5.10.3</junit5.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <commons-io.version>2.16.1</commons-io.version>
 
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     <!-- See http://www.eclemma.org/jacoco/trunk/doc/prepare-agent-mojo.html-->
@@ -90,12 +89,6 @@
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-runtime</artifactId>
         <version>[${antlr.version}]</version> <!-- Pin is HARD to this specific version -->
-      </dependency>
-
-      <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>${commons-io.version}</version>
       </dependency>
 
       <dependency>
@@ -338,7 +331,7 @@
         <configuration>
           <toolchains>
             <jdk>
-              <version>17</version>
+              <version>21</version>
             </jdk>
           </toolchains>
         </configuration>
@@ -407,7 +400,7 @@
                 </banDuplicateClasses>
 
                 <enforceBytecodeVersion>
-                  <maxJdkVersion>8</maxJdkVersion>
+                  <maxJdkVersion>11</maxJdkVersion>
                   <ignoredScopes>
                     <ignoredScope>test</ignoredScope>
                   </ignoredScopes>

--- a/renovate.json
+++ b/renovate.json
@@ -103,18 +103,6 @@
     },
     {
       "matchPackagePrefixes": [
-        "commons-",
-        "org.apache.commons"
-      ],
-      "groupSlug": "commons",
-      "groupName": "Apache Commons",
-      "labels": [
-        "apache-commons"
-      ],
-      "allowedVersions": "/^[0-9]{1,3}\\.[0-9]{1,3}(?:\\.[0-9]{1,3})?(?:-M[0-9]{1,3})?$/"
-    },
-    {
-      "matchPackagePrefixes": [
         "org.springframework",
         "io.springfox",
         "org.springdoc"


### PR DESCRIPTION
For whatever reason I couldn't get this project to build locally even after tweaking plugins, toolchains, etc. I'd love to see this as a zero dependency project as I'd like to use this more easily w/in the Clojure ecosystem with Babashka.