### PR TITLE
feat: take into account the global gitignore

### DIFF
--- a/gitignore-reader/src/test/resources/home/.config/git/ignore
+++ b/gitignore-reader/src/test/resources/home/.config/git/ignore
@@ -1,0 +1,1 @@
+/dir5/ignored_from_global_gitignore

--- a/gitignore-reader/src/test/resources/testtree/dir5/ignored_from_global_gitignore
+++ b/gitignore-reader/src/test/resources/testtree/dir5/ignored_from_global_gitignore
@@ -1,0 +1,1 @@
+This file should be ignored by the 'global' gitignore

--- a/gitignore-reader/src/test/resources/xdg_config_home/git/ignore
+++ b/gitignore-reader/src/test/resources/xdg_config_home/git/ignore
@@ -1,0 +1,1 @@
+/dir5/ignored_from_global_gitignore

--- a/pom.xml
+++ b/pom.xml
@@ -523,6 +523,16 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
+        <configuration>
+          <environmentVariables>
+            <XDG_CONFIG_HOME>src/test/resources/xdg_config_home</XDG_CONFIG_HOME>
+          </environmentVariables>
+        </configuration>
+      </plugin>
 
       <!-- Coverage analysis for tests -->
       <plugin>


### PR DESCRIPTION
git supports configuring a 'global gitignore'. By default its location is `$XDG_CONFIG_HOME/git/ignore` or else `$HOME/.config/git/ignore` by default, but can be set by the `core.excludesFile` setting.

This change makes gitignore-reader take that file into account as well. I suppose the 'proper' way to do that would be to parse `~/.gitconfig` to find the value of `core.excludesFile`. This change only picks it up from the default locations.