### PR TITLE
chore: filter duplicate GitLab users

### DIFF
--- a/enforcer/src/test/resources/__files/gitlab/ExtraUsers.json
+++ b/enforcer/src/test/resources/__files/gitlab/ExtraUsers.json
@@ -33,5 +33,18 @@
     },
     "expires_at": null,
     "membership_state": "active"
+  },
+  {
+    "id": 2,
+    "username": "niels",
+    "name": "Niels Basjes",
+    "state": "active",
+    "locked": false,
+    "avatar_url": "https://git.example.nl/uploads/-/system/user/avatar/2/avatar2.png",
+    "web_url": "https://git.example.nl/niels",
+    "access_level": 50,
+    "created_at": "2025-02-07T16:52:59.982Z",
+    "expires_at": null,
+    "membership_state": "active"
   }
 ]

--- a/enforcer/src/test/resources/__files/gitlab/NielsProject_MembersAll.json
+++ b/enforcer/src/test/resources/__files/gitlab/NielsProject_MembersAll.json
@@ -137,6 +137,19 @@
     "created_at": "2025-02-07T15:53:31.515Z",
     "expires_at": null,
     "membership_state": "active"
+  },
+  {
+    "id": 2,
+    "username": "niels",
+    "name": "Niels Basjes",
+    "state": "active",
+    "locked": false,
+    "avatar_url": "https://git.example.nl/uploads/-/system/user/avatar/2/avatar2.png",
+    "web_url": "https://git.example.nl/niels",
+    "access_level": 50,
+    "created_at": "2025-02-07T16:52:59.982Z",
+    "expires_at": null,
+    "membership_state": "active"
   }
 
 ]

--- a/enforcer/src/test/resources/__files/gitlab/NielsProject_MembersDirect.json
+++ b/enforcer/src/test/resources/__files/gitlab/NielsProject_MembersDirect.json
@@ -13,6 +13,19 @@
     "membership_state": "active"
   },
   {
+    "id": 2,
+    "username": "niels",
+    "name": "Niels Basjes",
+    "state": "active",
+    "locked": false,
+    "avatar_url": "https://secure.gravatar.com/avatar/1a1e9443d32983849de0a7a64aaad3?s=80&d=identicon",
+    "web_url": "https://gitlab.example.nl/niels",
+    "access_level": 50,
+    "created_at": "2018-02-12T09:45:46.648Z",
+    "expires_at": null,
+    "membership_state": "active"
+  },
+  {
     "id": 1,
     "username": "root",
     "name": "root",


### PR DESCRIPTION
Updated GitLab user check to filter on unique usernames.

After a configuration change in GitLab the API started returning duplicate users (sometimes with different timestamps). This change adds a filter on the streams to ensure we only keep distinct users based on their usernames.